### PR TITLE
Fix cdc-acm host_open flag being set too early

### DIFF
--- a/src/cdcacm_serial.c
+++ b/src/cdcacm_serial.c
@@ -191,7 +191,6 @@ void cdcacm_setup(void)
 	
 	acm_tx_state = ACM_TX_READY;
 	acm_rx_state = ACM_RX_READY;
-	curie_shared_data->cdc_acm_buffers_obj.host_open = true;
 	
 	ret = uart_line_ctrl_set(dev, LINE_CTRL_DSR, 1);
 
@@ -204,6 +203,8 @@ void cdcacm_setup(void)
 	ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);
 
 	uart_irq_callback_set(dev, interrupt_handler);
+
+	curie_shared_data->cdc_acm_buffers_obj.host_open = true;
 		
 	//reset head and tails values to 0
 	curie_shared_data->cdc_acm_shared_rx_buffer.head = 0;


### PR DESCRIPTION
-the host_open flag for the cdc-acm was being set too early which causes
the first few characters to not be printed on the serial terminal
-set it later on after the host finishes setting up the serial port