### PR TITLE
Remove BOARD definition from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc


### PR DESCRIPTION
This is already defined when building x86 and arc, in the
"compile-arc" and "compile-x86" targets in the main Makefiles for
CODK-M and CODK-Z