### PR TITLE
CDC-ACM fixes

### DIFF
--- a/src/cdcacm_serial.c
+++ b/src/cdcacm_serial.c
@@ -10,6 +10,7 @@
 
 #define RESET_BAUD              1200
 #define BAUDRATE_RESET_SLEEP    50
+#define TX_DELAY                40
 
 /* Make sure BUFFER_LENGTH is not bigger then shared ring buffers */
 #define BUFFER_LENGTH		128
@@ -18,7 +19,7 @@
 #define USB_DISCONNECTED    0x05
 
 #define SERIAL_READ_TIMEOUT	1000
-#define CDCACM_TX_DELAY		2000
+#define CDCACM_TX_DELAY		4000
 
 #define SCSS_RSTC   (uint32_t*)0xb0800570
 
@@ -53,6 +54,7 @@ static volatile uint32_t acm_tx_state = ACM_TX_DISABLED;
 static volatile bool data_transmitted;
 static volatile bool data_arrived = false;
 
+
 static void interrupt_handler(struct device *dev)
 {
 	uart_irq_update(dev);
@@ -81,13 +83,14 @@ static void read_data(struct device *dev, int *bytes_read)
 
 static void write_data(struct device *dev, const char *buf, int len)
 {
+	uart_irq_tx_enable(dev);
+
 	data_transmitted = false;
-	for(int i = 0; i < len; i++)
+	uart_fifo_fill(dev, (const uint8_t*)buf, len);
+	while (data_transmitted == false)
 	{
-		uart_poll_out(dev, buf[i]);
 	}
-	data_transmitted = true;
-	k_busy_wait(CDCACM_TX_DELAY);
+	uart_irq_tx_disable(dev);
 }
 
 void cdc_acm_tx()
@@ -109,6 +112,7 @@ void cdc_acm_tx()
 			{
 				gpio_pin_write(gpio_dev, TXRX_LED, 0);	//turn TXRX led on
 				write_data(dev, (const char*)write_buffer, cnt);
+				k_busy_wait(TX_DELAY * cnt);
 				gpio_pin_write(gpio_dev, TXRX_LED, 1);	//turn TXRX led off
 			}			
 		}
@@ -170,7 +174,7 @@ void init_cdc_acm()
 	curie_shared_data->cdc_acm_buffers_obj.host_open = false;
 }
 
-void cdcacm_setup()
+void cdcacm_setup(void *dummy1, void *dummy2, void *dummy3)
 {
 	uint32_t baudrate, dtr = 0;
 	int ret;
@@ -194,6 +198,7 @@ void cdcacm_setup()
 	ret = uart_line_ctrl_set(dev, LINE_CTRL_DSR, 1);
 
 	enableReboot = true;
+	k_yield();
 
 	gpio_dev= device_get_binding("GPIO_0");
 	gpio_pin_configure(gpio_dev, TXRX_LED, (GPIO_DIR_OUT));
@@ -205,50 +210,51 @@ void cdcacm_setup()
 	ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);
 
 	uart_irq_callback_set(dev, interrupt_handler);
-	
-	//reset head and tails values to 0
-	Tx_TAIL = 0;
-	Tx_HEAD = 0;
-	Rx_TAIL = 0;
-	Rx_HEAD = 0;
-
-	uart_irq_rx_enable(dev);
 
 	curie_shared_data->cdc_acm_buffers_obj.host_open = true;
+		
+	//reset head and tails values to 0
+	curie_shared_data->cdc_acm_shared_rx_buffer.head = 0;
+	curie_shared_data->cdc_acm_shared_rx_buffer.tail = 0;
+	curie_shared_data->cdc_acm_shared_tx_buffer.head = 0;
+	curie_shared_data->cdc_acm_shared_tx_buffer.tail = 0;
+	usbSetupDone = true;
 }
 
-void baudrate_reset()
+void baudrate_reset(void *dummy1, void *dummy2, void *dummy3)
 {
 	uint32_t baudrate, ret = 0;
-
-	ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);
-	if(baudrate == RESET_BAUD)
+	while(!enableReboot)
 	{
-		soft_reboot();
+		k_yield();
+	}
+	ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);	
+	while(1)
+	{
+		ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);
+		if(baudrate == RESET_BAUD)
+		{
+			soft_reboot();
+		}
+		k_sleep(BAUDRATE_RESET_SLEEP);
 	}
 }
 
-void usb_serial()
+void usb_serial(void *dummy1, void *dummy2, void *dummy3)
 {
-	uint32_t dtr = 0;
-	uart_line_ctrl_get(dev, LINE_CTRL_DTR, &dtr);
-	if(dtr)
+	while(!usbSetupDone)
 	{
-		if(curie_shared_data->cdc_acm_buffers_obj.host_open == false)
-		{
-			curie_shared_data->cdc_acm_buffers_obj.host_open = true;
-		}
+		k_yield();
+	}
+
+	/* Enable rx interrupts */
+	uart_irq_rx_enable(dev);
+
+	while (1) {
 		cdc_acm_tx();
 		cdc_acm_rx();
+		k_yield();
 	}
-	else
-	{
-		curie_shared_data->cdc_acm_buffers_obj.host_open = false;
-		//reset head and tails values to 0
-		Tx_TAIL = 0;
-		Tx_HEAD = 0;
-		Rx_TAIL = 0;
-		Rx_HEAD = 0;
-	}
+	
 }
 

--- a/src/cdcacm_serial.h
+++ b/src/cdcacm_serial.h
@@ -8,11 +8,11 @@ void cdc_acm_rx();
 
 void init_cdc_acm();
 
-void cdcacm_setup();
+void cdcacm_setup(void *dummy1, void *dummy2, void *dummy3);
 
-void baudrate_reset();
+void baudrate_reset(void *dummy1, void *dummy2, void *dummy3);
 
-void usb_serial();
+void usb_serial(void *dummy1, void *dummy2, void *dummy3);
 
 #ifdef __cplusplus
 }

--- a/src/curie_shared_mem.h
+++ b/src/curie_shared_mem.h
@@ -23,18 +23,6 @@
 #define SERIAL_BUFFER_SIZE 256
 #define SHARED_BUFFER_SIZE 64
 
-/**
- * Use the following defines just to make the tips of your finger happier.
- */
-
-#define Rx_BUFF curie_shared_data->cdc_acm_shared_rx_buffer.data
-#define Rx_HEAD curie_shared_data->cdc_acm_shared_rx_buffer.head
-#define Rx_TAIL curie_shared_data->cdc_acm_shared_rx_buffer.tail
-#define Tx_BUFF curie_shared_data->cdc_acm_shared_tx_buffer.data
-#define Tx_HEAD curie_shared_data->cdc_acm_shared_tx_buffer.head
-#define Tx_TAIL curie_shared_data->cdc_acm_shared_tx_buffer.tail
-#define SBS     SERIAL_BUFFER_SIZE
-
 struct cdc_ring_buffer
 {
     /** Ring buffer data */
@@ -43,6 +31,7 @@ struct cdc_ring_buffer
     volatile int head;
     /** Ring buffer tail index, modified by consumer */
     volatile int tail;
+    volatile uint8_t lock;
 };
 
 struct cdc_acm_shared_data {


### PR DESCRIPTION
-reverts 15095c4dc918894e4e29afac39faa91dca577b34
-works around a bug where an extra 4 bytes were being received on the
host side https://jira.zephyrproject.org/browse/ZEP-2074
-fixes an issue where the value being read from shared memory ring
buffer is incorrect