### PR TITLE
CDC-ACM fixes

### DIFF
--- a/src/cdcacm_serial.h
+++ b/src/cdcacm_serial.h
@@ -8,11 +8,11 @@ void cdc_acm_rx();
 
 void init_cdc_acm();
 
-void cdcacm_setup();
+void cdcacm_setup(void *dummy1, void *dummy2, void *dummy3);
 
-void baudrate_reset();
+void baudrate_reset(void *dummy1, void *dummy2, void *dummy3);
 
-void usb_serial();
+void usb_serial(void *dummy1, void *dummy2, void *dummy3);
 
 #ifdef __cplusplus
 }

--- a/src/curie_shared_mem.h
+++ b/src/curie_shared_mem.h
@@ -23,18 +23,6 @@
 #define SERIAL_BUFFER_SIZE 256
 #define SHARED_BUFFER_SIZE 64
 
-/**
- * Use the following defines just to make the tips of your finger happier.
- */
-
-#define Rx_BUFF curie_shared_data->cdc_acm_shared_rx_buffer.data
-#define Rx_HEAD curie_shared_data->cdc_acm_shared_rx_buffer.head
-#define Rx_TAIL curie_shared_data->cdc_acm_shared_rx_buffer.tail
-#define Tx_BUFF curie_shared_data->cdc_acm_shared_tx_buffer.data
-#define Tx_HEAD curie_shared_data->cdc_acm_shared_tx_buffer.head
-#define Tx_TAIL curie_shared_data->cdc_acm_shared_tx_buffer.tail
-#define SBS     SERIAL_BUFFER_SIZE
-
 struct cdc_ring_buffer
 {
     /** Ring buffer data */
@@ -43,6 +31,7 @@ struct cdc_ring_buffer
     volatile int head;
     /** Ring buffer tail index, modified by consumer */
     volatile int tail;
+    volatile uint8_t lock;
 };
 
 struct cdc_acm_shared_data {

--- a/src/main.c
+++ b/src/main.c
@@ -32,18 +32,24 @@
 #define SOFTRESET_INTERRUPT_PIN		0
 
 /* size of stack area used by each thread */
-#define MAIN_STACKSIZE      3072
+#define MAIN_STACKSIZE      2048
+#define CDCACM_STACKSIZE    384
+#define RESET_STACKSIZE     384
+#define USBSERIAL_STACKSIZE 384
 #define FAULTLED_STACKSIZE  256
 
 /* scheduling priority used by each thread */
 #define PRIORITY 7
-#define TASK_PRIORITY 7
+#define TASK_PRIORITY 8
 
 #define ARDUINO_101_VID		0x8087
 #define ARDUINO_101_PID		0x0AB6
 
 #define MAX_DESCRIPTOR_LENGTH	64
 
+char __noinit __stack cdcacm_setup_stack_area[CDCACM_STACKSIZE];
+char __noinit __stack baudrate_reset_stack_area[RESET_STACKSIZE];
+char __noinit __stack usb_serial_stack_area[USBSERIAL_STACKSIZE];
 char __noinit __stack fault_led_stack_area[FAULTLED_STACKSIZE];
 
 const char *vendor = "Intel";
@@ -103,7 +109,7 @@ void cdc_acm_descriptor_callback (cdc_acm_cfg_t *cfg)
 	}
 }
 
-void threadMain()
+void threadMain(void *dummy1, void *dummy2, void *dummy3)
 {
 
 	init_cdc_acm();
@@ -116,23 +122,17 @@ void threadMain()
 	reset_vector = (uint32_t *)RESET_VECTOR;
 	start_arc(*reset_vector);
 
-	k_thread_spawn(fault_led_stack_area, FAULTLED_STACKSIZE, check_arc_error, NULL, NULL,
+	k_thread_spawn(cdcacm_setup_stack_area, CDCACM_STACKSIZE, cdcacm_setup, NULL, NULL,
+			NULL, TASK_PRIORITY, 0, K_NO_WAIT);
+	
+	k_thread_spawn(baudrate_reset_stack_area, RESET_STACKSIZE, baudrate_reset, NULL, NULL,
+			NULL, TASK_PRIORITY, 0, K_NO_WAIT);
+	
+	k_thread_spawn(usb_serial_stack_area, USBSERIAL_STACKSIZE, usb_serial, NULL, NULL,
 			NULL, TASK_PRIORITY, 0, K_NO_WAIT);
 
-	cdcacm_setup();
-
-	int i = 0;
-
-	while(1)
-	{
-		if(!(i%10))
-		{
-			baudrate_reset();
-			k_yield();
-		}
-		usb_serial();
-		i++;
-	}
+	k_thread_spawn(fault_led_stack_area, FAULTLED_STACKSIZE, check_arc_error, NULL, NULL,
+			NULL, TASK_PRIORITY, 0, K_NO_WAIT);
 
 }
 


### PR DESCRIPTION
-fixes several issues with cdc-acm serial port
-allows opening and closing of serial port repeatedly
-fixes issues of extra or missing characters on the serial port
-cdc-acm is now back to being a separate thread